### PR TITLE
メインライブラリのバージョンアップに追従

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,13 +1,17 @@
-# Release 1.17 (2021-05-??)
+# Release 1.17 (2021-05-25)
 
 ## EN
 
+- Some JSON params are added to `oiyokan-settings.json`: autoCommit, jdbcFetchSize, filterEqAutoSelect。
+- Added ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY to collection Statement.
 - Use java.sql.Statement for parameterless queries.
 
 ## JA
 
-- パラメータなしクエリは java.sql.Statement を利用する 
-- 上記: 各DBで確認済み
+- `oiyokan-settings.json` にいくつかの JSON パラメータを追加: autoCommit, jdbcFetchSize, filterEqAutoSelect。
+- 一覧取得Statementに ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY 指定を追加。
+- パラメータなしクエリは java.sql.Statement を利用。
+- 上記: 各DBで確認済み。
 
 # Release 1.16 (2021-05-22)
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 		<dependency>
 			<groupId>jp.igapyon.oiyokan</groupId>
 			<artifactId>oiyokan</artifactId>
-			<version>1.16.20210524e-SNAPSHOT</version>
+			<version>1.16.20210525d-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,9 @@
 
 	<groupId>jp.igapyon.oiyokan</groupId>
 	<artifactId>oiyokan-unittest</artifactId>
-	<version>1.16.20210524a</version>
+	<version>1.17.20210525a</version>
 	<name>oiyokan-unittest</name>
-	<description>Oiyokan is a simple OData v4 Server. (based on Apache
+	<description>UnitTest of Oiyokan. Oiyokan is a simple OData v4 Server. (based on Apache
 		Olingo / h2 database)</description>
 	<url>https://github.com/igapyon/oiyokan</url>
 
@@ -86,7 +86,7 @@
 		<dependency>
 			<groupId>jp.igapyon.oiyokan</groupId>
 			<artifactId>oiyokan</artifactId>
-			<version>1.16.20210525d-SNAPSHOT</version>
+			<version>1.17.20210525e</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/jp/oiyokan/unittest/OiyokanUnittestConstants.java
+++ b/src/main/java/jp/oiyokan/unittest/OiyokanUnittestConstants.java
@@ -19,5 +19,5 @@ package jp.oiyokan.unittest;
  * Oiyokan UnitTest の定数.
  */
 public class OiyokanUnittestConstants {
-    public static final String VERSION = "1.16.20210524a";
+    public static final String VERSION = "1.17.20210525a";
 }

--- a/src/test/java/jp/oiyokan/core/db/testdb/entity/UnitTestTypeChar01Test.java
+++ b/src/test/java/jp/oiyokan/core/db/testdb/entity/UnitTestTypeChar01Test.java
@@ -53,8 +53,10 @@ class UnitTestTypeChar01Test {
         /// 通常のfilter
         resp = OiyokanTestUtil.callGet("/ODataTest3", "$filter=ID eq " + idString + "&$select=StringChar8");
         result = OiyokanTestUtil.stream2String(resp.getContent());
-        assertEquals("{\"@odata.context\":\"$metadata#ODataTest3\",\"value\":[{\"ID\":" + idString
-                + ",\"StringChar8\":\"  C456  \"}]}", result, "前後空白付きでFILTER検索できることを確認.");
+        assertEquals(
+                "{\"@odata.context\":\"$metadata#ODataTest3\",\"value\":[{\"@odata.id\":\"ODataTest3(" + idString
+                        + ")\",\"ID\":" + idString + ",\"StringChar8\":\"  C456  \"}]}",
+                result, "前後空白付きでFILTER検索できることを確認.");
         assertEquals(200, resp.getStatusCode());
 
         // DELETE

--- a/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery03Test.java
+++ b/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery03Test.java
@@ -43,8 +43,7 @@ class UnitTestQuery03Test {
 
         switch (databaseType) {
         default:
-            assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1,\"Boolean1\":false}]}",
-                    result);
+            assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1}]}", result);
             assertEquals(200, resp.getStatusCode());
             break;
         case ORCL18:

--- a/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery04Test.java
+++ b/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery04Test.java
@@ -38,7 +38,7 @@ class UnitTestQuery04Test {
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
         // System.err.println("result: " + result);
-        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1,\"Int16a\":32767}]}", result);
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1}]}", result);
         assertEquals(200, resp.getStatusCode());
     }
 }

--- a/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery05Test.java
+++ b/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery05Test.java
@@ -39,9 +39,7 @@ class UnitTestQuery05Test {
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
         // System.err.println("result: " + result);
-        assertEquals(
-                "{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1,\"Int32a\":2147483647},{\"ID\":2,\"Int32a\":2147483647}]}",
-                result);
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1},{\"ID\":2}]}", result);
         assertEquals(200, resp.getStatusCode());
     }
 }

--- a/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery06Test.java
+++ b/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery06Test.java
@@ -39,9 +39,7 @@ class UnitTestQuery06Test {
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
         // System.err.println("result: " + result);
-        assertEquals(
-                "{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":3,\"Int64a\":2147483647},{\"ID\":4,\"Int64a\":2147483647}]}",
-                result);
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":3},{\"ID\":4}]}", result);
         assertEquals(200, resp.getStatusCode());
     }
 }

--- a/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery07Test.java
+++ b/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery07Test.java
@@ -38,9 +38,7 @@ class UnitTestQuery07Test {
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
         // System.err.println("result: " + result);
-        assertEquals(
-                "{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":3,\"Decimal1\":1234.56},{\"ID\":4,\"Decimal1\":1234.56}]}",
-                result);
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":3},{\"ID\":4}]}", result);
         assertEquals(200, resp.getStatusCode());
     }
 }

--- a/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery08Test.java
+++ b/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery08Test.java
@@ -38,7 +38,7 @@ class UnitTestQuery08Test {
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
         // System.err.println("result: " + result);
-        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1,\"Sbyte1\":127}]}", result);
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1}]}", result);
         assertEquals(200, resp.getStatusCode());
     }
 }

--- a/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery09Test.java
+++ b/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery09Test.java
@@ -45,8 +45,7 @@ class UnitTestQuery09Test {
 
         switch (databaseType) {
         default:
-            assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1,\"Single1\":123.45}]}",
-                    result, "Single型の確認");
+            assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1}]}", result, "Single型の確認");
             assertEquals(200, resp.getStatusCode());
             break;
         case PostgreSQL:

--- a/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery11Test.java
+++ b/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery11Test.java
@@ -39,8 +39,7 @@ class UnitTestQuery11Test {
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
         // System.err.println("result: " + result);
-        assertEquals(
-                "{\"@odata.context\":\"$metadata#ODataTest1\",\"@odata.count\":1,\"value\":[{\"ID\":204,\"StringVar255\":\"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"}]}",
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"@odata.count\":1,\"value\":[{\"ID\":204}]}",
                 result);
         assertEquals(200, resp.getStatusCode());
     }

--- a/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery12Test.java
+++ b/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery12Test.java
@@ -53,8 +53,7 @@ class UnitTestQuery12Test {
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
         // System.err.println("result: " + result);
-        assertEquals(
-                "{\"@odata.context\":\"$metadata#ODataTest1\",\"@odata.count\":1,\"value\":[{\"ID\":204,\"StringVar255\":\"ABCDEFGHIJKLMNOPQRSTUVWXYZ\",\"StringLongVar1\":\"ABCDEFGHIJKLMNOPQRSTUVWXYZ\",\"Clob1\":\"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"}]}",
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"@odata.count\":1,\"value\":[{\"ID\":204}]}",
                 result, "検索できることの確認.");
         assertEquals(200, resp.getStatusCode());
     }

--- a/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery13Test.java
+++ b/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery13Test.java
@@ -39,8 +39,7 @@ class UnitTestQuery13Test {
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
         // System.err.println("result: " + result);
-        assertEquals(
-                "{\"@odata.context\":\"$metadata#ODataTest1\",\"@odata.count\":1,\"value\":[{\"ID\":204,\"StringLongVar1\":\"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"}]}",
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"@odata.count\":1,\"value\":[{\"ID\":204}]}",
                 result);
         assertEquals(200, resp.getStatusCode());
     }

--- a/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery14Test.java
+++ b/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQuery14Test.java
@@ -53,8 +53,7 @@ class UnitTestQuery14Test {
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
         // System.err.println("result: " + result);
-        assertEquals(
-                "{\"@odata.context\":\"$metadata#ODataTest1\",\"@odata.count\":1,\"value\":[{\"ID\":204,\"Clob1\":\"ABCDEFGHIJKLMNOPQRSTUVWXYZ\"}]}",
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"@odata.count\":1,\"value\":[{\"ID\":204}]}",
                 result, "検索できることの確認.");
         assertEquals(200, resp.getStatusCode());
     }

--- a/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQueryBinaryEq01Test.java
+++ b/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQueryBinaryEq01Test.java
@@ -40,9 +40,7 @@ class UnitTestQueryBinaryEq01Test {
                 OiyoUrlUtil.encodeUrlQuery("&$filter=Int32a eq Int64a &$top=2 &$select=ID &$orderby=ID asc"));
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
-        assertEquals(
-                "{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1,\"Int32a\":2147483647,\"Int64a\":2147483647},{\"ID\":2,\"Int32a\":2147483647,\"Int64a\":2147483647}]}",
-                result);
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1},{\"ID\":2}]}", result);
         assertEquals(200, resp.getStatusCode());
     }
 }

--- a/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQueryBinaryEq02Test.java
+++ b/src/test/java/jp/oiyokan/core/db/testdb/query/UnitTestQueryBinaryEq02Test.java
@@ -40,8 +40,7 @@ class UnitTestQueryBinaryEq02Test {
                 OiyoUrlUtil.encodeUrlQuery("&$filter=32767 eq Int16a &$top=3 &$select=ID &$orderby=ID asc"));
         final String result = OiyokanTestUtil.stream2String(resp.getContent());
 
-        assertEquals(
-                "{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1,\"Int16a\":32767},{\"ID\":2,\"Int16a\":32767},{\"ID\":3,\"Int16a\":32767}]}",
+        assertEquals("{\"@odata.context\":\"$metadata#ODataTest1\",\"value\":[{\"ID\":1},{\"ID\":2},{\"ID\":3}]}",
                 result);
         assertEquals(200, resp.getStatusCode());
     }

--- a/src/test/java/jp/oiyokan/unittest/db/sakila/SakilaValueNullTest.java
+++ b/src/test/java/jp/oiyokan/unittest/db/sakila/SakilaValueNullTest.java
@@ -47,7 +47,7 @@ class SakilaValueNullTest {
 
         // 検索結果が存在するべき。
         assertEquals(
-                "{\"@odata.context\":\"$metadata#SklAddresses\",\"@odata.count\":4,\"value\":[{\"address_id\":1,\"address2\":null}]}",
+                "{\"@odata.context\":\"$metadata#SklAddresses\",\"@odata.count\":4,\"value\":[{\"address_id\":1}]}",
                 result, "eq で右辺が null リテラルの処理");
         assertEquals(200, resp.getStatusCode());
     }
@@ -70,7 +70,7 @@ class SakilaValueNullTest {
 
         // 検索結果が存在するべき。
         assertEquals(
-                "{\"@odata.context\":\"$metadata#SklAddresses\",\"@odata.count\":4,\"value\":[{\"address_id\":1,\"address2\":null}]}",
+                "{\"@odata.context\":\"$metadata#SklAddresses\",\"@odata.count\":4,\"value\":[{\"address_id\":1}]}",
                 result, "eq で左辺が null リテラルの処理");
         assertEquals(200, resp.getStatusCode());
     }


### PR DESCRIPTION
- `oiyokan-settings.json` にいくつかの JSON パラメータを追加: autoCommit, jdbcFetchSize, filterEqAutoSelect。
- 一覧取得Statementに ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY 指定を追加。
- パラメータなしクエリは java.sql.Statement を利用。