### PR TITLE
Release 1.20 (2021-06-13)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,13 @@
+# Release 1.20 (2021-06-13)
+
+## EN
+
+- Fixed an issue that caused h2 and SQL Server to malfunction when Oiyokan was run with Database "autoCommit": false.
+
+## JA
+
+- Oiyokan を Database "autoCommit": false で動作させた際に h2 および SQL Server で動作不良を起こす問題を修正。
+
 # Release 1.19 (2021-06-03)
 
 ## EN

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 		<dependency>
 			<groupId>jp.igapyon.oiyokan</groupId>
 			<artifactId>oiyokan</artifactId>
-			<version>1.19.20210603a</version>
+			<version>1.19.20210613a-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>jp.igapyon.oiyokan</groupId>
 	<artifactId>oiyokan-unittest</artifactId>
-	<version>1.19.20210603a</version>
+	<version>1.20.20210613a</version>
 	<name>oiyokan-unittest</name>
 	<description>UnitTest of Oiyokan. Oiyokan is a simple OData v4 Server. (based on Apache
 		Olingo / h2 database)</description>
@@ -86,7 +86,7 @@
 		<dependency>
 			<groupId>jp.igapyon.oiyokan</groupId>
 			<artifactId>oiyokan</artifactId>
-			<version>1.19.20210613a-SNAPSHOT</version>
+			<version>1.20.20210613a</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
# Release 1.20 (2021-06-13)

## EN

- Fixed an issue that caused h2 and SQL Server to malfunction when Oiyokan was run with Database "autoCommit": false.

## JA

- Oiyokan を Database "autoCommit": false で動作させた際に h2 および SQL Server で動作不良を起こす問題を修正。
